### PR TITLE
fix getting active plugins in multisite environment

### DIFF
--- a/src/DetectPluginAssets.php
+++ b/src/DetectPluginAssets.php
@@ -47,6 +47,13 @@ class DetectPluginAssets
 
             $activePlugins = get_option('active_plugins');
 
+            if (is_multisite()) {
+                $activeSitewidePlugins = get_site_option('active_sitewide_plugins');
+                $activeSitewidePlugins = array_keys($activeSitewidePlugins);
+
+                $activePlugins = array_unique(array_merge($activePlugins, $activeSitewidePlugins));
+            }
+
             $activePluginDirs = array_map(
                 static function ($activePlugin): string {
                     return explode('/', $activePlugin)[0];


### PR DESCRIPTION
As discussed in https://github.com/leonstafford/wp2static/issues/730 WordPress stores network active plugins of a Wordpress multisite environment in the `active_sitewide_plugins` option of the `wp_sitemeta` table. This option can be accessed using `get_site_option`.

We need to merge these plugins with the blog's active plugins in order to get a list of all active plugins for a single blog.